### PR TITLE
Add deleteat!(::Tape, ...)

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -42,6 +42,7 @@ mkcall
 push!
 insert!
 replace!
+deleteat!
 primitivize!
 ```
 

--- a/docs/src/tape.md
+++ b/docs/src/tape.md
@@ -116,6 +116,21 @@ replace!(tape, 4 => [new_op1, new_op2]; rebind_to=2)
 println(tape)
 ```
 
+[`deleteat!`](@ref) is used to remove entries from the tape.
+```@example
+using Ghost                             # hide
+import Ghost: Tape, V, inputs!, mkcall  # hide
+tape = Tape()                           # hide
+_, v1, v2 = inputs!(tape, nothing, 3.0, 5.0) # hide
+v3 = push!(tape, mkcall(*, v1, 2))      # hide
+v4 = push!(tape, mkcall(+, v3, v1))     # hide
+v5 = push!(tape, mkcall(+, v4, v2))     # hide
+v6 = push!(tape, mkcall(+, v4, v1))     # hide
+
+deleteat!(tape, 5; rebind_to = 1)
+println(tape)
+```
+
 Although [`trace`](@ref) creates a tape consisting only of primitives, tape itself can hold any function calls. It's possible to decompose all non-primitive calls on the tape to lists of corresponding primitives using [`primitivize!`](@ref).
 
 ```@example

--- a/src/tape.jl
+++ b/src/tape.jl
@@ -343,6 +343,23 @@ Base.replace!(
         idx_ops::Pair{<:AbstractOp, <:Union{Tuple,Vector}};
         kwargs...) = replace!(tape, idx_ops[1].id => idx_ops[2]; kwargs...)
 
+function Base.deleteat!(tape::Tape, idx::Integer; rebind_to)
+    # delete and rebind
+    deleteat!(tape.ops, idx)
+    rebind!(tape, Dict(idx => rebind_to))
+
+    # shift indices for outputs up
+    for i in idx:length(tape)
+        tape.ops[i].id -= 1
+    end
+
+    return tape
+end
+Base.deleteat!(tape::Tape, idx::Variable; rebind_to) =
+    deleteat!(tape, idx.id; rebind_to = rebind_to)
+Base.deleteat!(tape::Tape, idx::AbstractOp; rebind_to) =
+    deleteat!(tape, idx.id; rebind_to = rebind_to)
+
 ########################################################################
 #                       SPECIAL OPERATIONS                             #
 ########################################################################

--- a/src/tape.jl
+++ b/src/tape.jl
@@ -344,17 +344,18 @@ Base.replace!(
         kwargs...) = replace!(tape, idx_ops[1].id => idx_ops[2]; kwargs...)
 
 """
-    deleteat!(tape::Tape, idx; rebind_to)
+    deleteat!(tape::Tape, idx; rebind_to = nothing)
 
-Remove `tape[V(idx)]` from the `tape` and
+Remove `tape[V(idx)]` from the `tape`.
+If `rebind_to` is not `nothing`, then
 replace all references to `V(idx)` with `V(rebind_to)`.
 
 `idx` may be an index or `Variable`/`AbstractOp` directly.
 """
-function Base.deleteat!(tape::Tape, idx::Integer; rebind_to)
+function Base.deleteat!(tape::Tape, idx::Integer; rebind_to = nothing)
     # delete and rebind
     deleteat!(tape.ops, idx)
-    rebind!(tape, Dict(idx => rebind_to))
+    isnothing(rebind_to) || rebind!(tape, Dict(idx => rebind_to))
 
     # shift indices for outputs up
     for i in idx:length(tape)
@@ -363,10 +364,10 @@ function Base.deleteat!(tape::Tape, idx::Integer; rebind_to)
 
     return tape
 end
-Base.deleteat!(tape::Tape, idx::Variable; rebind_to) =
-    deleteat!(tape, idx.id; rebind_to = rebind_to)
-Base.deleteat!(tape::Tape, idx::AbstractOp; rebind_to) =
-    deleteat!(tape, idx.id; rebind_to = rebind_to)
+Base.deleteat!(tape::Tape, idx::Variable; kwargs...) =
+    deleteat!(tape, idx.id; kwargs...)
+Base.deleteat!(tape::Tape, idx::AbstractOp; kwargs...) =
+    deleteat!(tape, idx.id; kwargs...)
 
 ########################################################################
 #                       SPECIAL OPERATIONS                             #

--- a/src/tape.jl
+++ b/src/tape.jl
@@ -343,6 +343,14 @@ Base.replace!(
         idx_ops::Pair{<:AbstractOp, <:Union{Tuple,Vector}};
         kwargs...) = replace!(tape, idx_ops[1].id => idx_ops[2]; kwargs...)
 
+"""
+    deleteat!(tape::Tape, idx; rebind_to)
+
+Remove `tape[V(idx)]` from the `tape` and
+replace all references to `V(idx)` with `V(rebind_to)`.
+
+`idx` may be an index or `Variable`/`AbstractOp` directly.
+"""
 function Base.deleteat!(tape::Tape, idx::Integer; rebind_to)
     # delete and rebind
     deleteat!(tape.ops, idx)

--- a/test/test_tape.jl
+++ b/test/test_tape.jl
@@ -78,6 +78,12 @@ import Ghost: Tape, V, inputs!, rebind!, mkcall, primitivize!
     @test tape3[V(6)].args[1].id == 1
     @test all(x -> x[1].id == x[2], zip(tape3, 1:length(tape3)))
 
+    tape = Tape()
+    _, v1, v2 = inputs!(tape, nothing, 3.0, 5.0)
+    v3 = push!(tape, mkcall(println, "Test"))
+    deleteat!(tape, v3)
+    @test length(tape) == 3
+
     # primitivize!
     f(x) = 2x - 1
     g(x) = f(x) + 5

--- a/test/test_tape.jl
+++ b/test/test_tape.jl
@@ -54,6 +54,30 @@ import Ghost: Tape, V, inputs!, rebind!, mkcall, primitivize!
     replace!(tape3, tape3[V(4)] => [op1, op2]; rebind_to=2)
     @test tape3[V(7)].args[1].id == op2.id
 
+    # deleteat!
+    tape = Tape()
+    _, v1, v2 = inputs!(tape, nothing, 3.0, 5.0)
+    v3 = push!(tape, mkcall(*, v1, 2))
+    v4 = push!(tape, mkcall(+, v3, v1))
+    v5 = push!(tape, mkcall(+, v4, v2))
+    v6 = push!(tape, mkcall(+, v4, v1))
+    tape2, tape3 = deepcopy(tape), deepcopy(tape)
+
+    deleteat!(tape, 5; rebind_to = 1)
+    @test tape[V(5)].args[1].id == 1
+    @test tape[V(6)].args[1].id == 1
+    @test all(x -> x[1].id == x[2], zip(tape, 1:length(tape)))
+
+    deleteat!(tape2, 5; rebind_to = 1)
+    @test tape2[V(5)].args[1].id == 1
+    @test tape2[V(6)].args[1].id == 1
+    @test all(x -> x[1].id == x[2], zip(tape2, 1:length(tape2)))
+
+    deleteat!(tape3, 5; rebind_to = 1)
+    @test tape3[V(5)].args[1].id == 1
+    @test tape3[V(6)].args[1].id == 1
+    @test all(x -> x[1].id == x[2], zip(tape3, 1:length(tape3)))
+
     # primitivize!
     f(x) = 2x - 1
     g(x) = f(x) + 5


### PR DESCRIPTION
This adds `deleteat!(tape::Tape, idx; rebind_to)`. It will remove `tape[V(idx)]`, shift the remaining output IDs up by 1, and rebind all references to `V(idx)` with `V(rebind_to)`. Tests are added as well.

Perhaps a better syntax would be `deleteat!(tape::Tape, idx => rebind_to)`, since `rebind_to` must always be specified.