### PR TITLE
Allow mkcall(fn, ...) to accept instances of structs for fn

### DIFF
--- a/src/tape.jl
+++ b/src/tape.jl
@@ -120,19 +120,19 @@ Base.show(io::IO, op::Constant) = print(io, "const %$(op.id) = $(op.val)::$(op.t
 Operation represening function call on tape. Typically, calls
 are constructed using [`mkcall`](@ref) function.
 
-Important fields of a Call:
+Important fields of a Call{T}:
 
-* `fn::Union{Function,Type,Variable}` - function or object to be called
+* `fn::T` - function or object to be called
 * `args::Vector` - vector of variables or values used as arguments
 * `val::Any` - the result of the function call
 """
-mutable struct Call <: AbstractOp
+mutable struct Call{T} <: AbstractOp
     id::Int
     val::Any
-    fn::Union{Function,Type,Variable}
+    fn::T
     args::Vector{Any}   # vector of Variables or const values
 end
-
+Call(id, val, fn::T, args) where T = Call{T}(id, val, fn, args)
 
 pretty_type_name(T) = string(T)
 pretty_type_name(T::Type{<:Broadcast.Broadcasted}) = "Broadcasted{}"
@@ -160,7 +160,7 @@ Convenient constructor for Call operation. If val is `missing` (default)
 and call value can be calculated from (bound) variables and constants,
 they are calculated. To prevent this behavior, set val to some neutral value.
 """
-function mkcall(fn::Union{Function,Type,Variable}, args...; val=missing)
+function mkcall(fn, args...; val=missing)
     fargs = (fn, args...)
     calculable = all(
         a -> !isa(a, Variable) ||                      # not variable


### PR DESCRIPTION
Currently, if we create an struct, `foo = Foo(...)`, then we push onto the tape something like `push!(tape, mkcall(+, foo, Ghost.V(...))`, we get a closure over `foo` when the tape is compiled. The current type signature of `Call` and `mkcall` restrict the following closure from being possible:
```julia
foo = Foo(...)
push!(tape, mkcall(foo, Ghost.V(...), ...))
```

This PR allows this by parameterizing `Call{T}` where `T == typeof(Call.fn)`. Then it removes the type restrictions on `fn` in `mkcall`. Tests seem to still pass. And this now works:
```julia
julia> tape = Ghost.Tape()
Tape{Dict{Any, Any}}


julia> v1, v2 = Ghost.inputs!(tape, 1, 2.0)
2-element Vector{Ghost.Variable}:
 %1
 %2

julia> foo1 = Foo([1, 2, 3, 4])
Foo{Vector{Int64}}([1, 2, 3, 4])

julia> push!(tape, Ghost.mkcall(foo1, v1, v2))
%3

julia> tape
Tape{Dict{Any, Any}}
  inp %1::Int64
  inp %2::Float64
  %3 = Foo{Vector{Int64}}([1, 2, 3, 4])(%1, %2)::Vector{Float64}


julia> tape.result = Ghost.V(3)
%3

julia> Ghost.to_expr(tape)
:(function var"##tape_1#257"(x1::Int64, x2::Float64)
      x3 = (Foo{Vector{Int64}}([1, 2, 3, 4]))(x1, x2)
      return x3
  end)

julia> sim = Ghost.compile(tape)
##tape_1#258 (generic function with 1 method)

julia> sim(1, 2.0)
4-element Vector{Float64}:
  5.0
  8.0
 11.0
 14.0

julia> foo1.x[3] = 10
10

julia> foo1
Foo{Vector{Int64}}([1, 2, 10, 4])

julia> sim(1, 2.0)
4-element Vector{Float64}:
  5.0
  8.0
 32.0
 14.0
```